### PR TITLE
Fix URI.escape

### DIFF
--- a/lib/omniauth/strategies/smart.rb
+++ b/lib/omniauth/strategies/smart.rb
@@ -164,7 +164,7 @@ module OmniAuth
 
       # SMART protocol requires submitting the url with encoded parameters
       def url_with_encoded_params(uri, params)
-        "#{URI.escape(uri)}?#{URI.encode_www_form(params)}"
+        "#{URI::Parser.new.escape(uri)}?#{URI.encode_www_form(params)}"
       end
 
       def redirect_uri


### PR DESCRIPTION
## Description
Ruby 3 does not support URI.escape anymore so we need to fix this logic