### PR TITLE
Add optional support for PKCE auth flow

### DIFF
--- a/lib/omniauth/smart/authorization.rb
+++ b/lib/omniauth/smart/authorization.rb
@@ -11,12 +11,16 @@ module OmniAuth
         @token_url = token_url
       end
 
-      def exchange_code_for_token(client, code, redirect_uri)
+      def exchange_code_for_token(client, code, redirect_uri, code_verifier = nil)
         data = {
-            code: code,
-            grant_type: 'authorization_code',
-            redirect_uri: redirect_uri
+          code: code,
+          grant_type: 'authorization_code',
+          redirect_uri: redirect_uri
         }
+
+        # Include the code verifier if provided
+        data[:code_verifier] = code_verifier if code_verifier
+
         if client.is_public?
           data["client_id"] = client.client_id
         end

--- a/lib/omniauth/smart/client.rb
+++ b/lib/omniauth/smart/client.rb
@@ -7,7 +7,7 @@
 module OmniAuth
   module Smart
     class Client
-      attr_accessor :issuer, :client_id, :client_secret, :org_id, :scope
+      attr_accessor :issuer, :client_id, :client_secret, :org_id, :scope, :use_pkce
 
       def initialize(**args)
         @issuer = args[:issuer]
@@ -15,6 +15,7 @@ module OmniAuth
         @client_secret = args[:client_secret]
         @org_id = args[:org_id]
         @scope = args[:scope]
+        @use_pkce = args[:use_pkce]
       end
 
       def is_confidential?


### PR DESCRIPTION
This allows clients to optionally require the PKCE flow during authentication with associated tests.